### PR TITLE
fix(DriverRemoteConnection): return the promise on close

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/driver/driver-remote-connection.js
@@ -190,16 +190,16 @@ class DriverRemoteConnection extends RemoteConnection {
    * @return {Promise}
    */
   close() {
-    if (this._closePromise) {
-      return this._closePromise;
-    }
-    this._closePromise = new Promise(resolve => {
-      this._ws.on('close', function () {
-        this.isOpen = false;
-        resolve();
+    if (!this._closePromise) {
+      this._closePromise = new Promise(resolve => {
+        this._ws.on('close', function () {
+          this.isOpen = false;
+          resolve();
+        });
+        this._ws.close();
       });
-      this._ws.close();
-    });
+    }
+    return this._closePromise;
   }
 }
 


### PR DESCRIPTION
The jsdoc indicates that the `DriverRemoteConnection.close()` method returns a `Promise`; however, the first time the method is called it returns `undefined`.